### PR TITLE
added cacheReset parameter

### DIFF
--- a/_build/build.transport.php
+++ b/_build/build.transport.php
@@ -4,7 +4,7 @@
  *
  * @package getcache
  * @subpackage build
- * @version 1.0.0-pl
+ * @version 1.0.1-dev
  * @author Jason Coward <jason@modx.com>
  */
 $mtime = microtime();
@@ -25,8 +25,8 @@ unset($root);
 
 /* package defines */
 define('PKG_NAME','getCache');
-define('PKG_VERSION','1.0.0');
-define('PKG_RELEASE','pl');
+define('PKG_VERSION','1.0.1');
+define('PKG_RELEASE','dev');
 define('PKG_LNAME',strtolower(PKG_NAME));
 
 // override with your own defines here (see build.config.sample.php)

--- a/_build/properties/properties.getcache.php
+++ b/_build/properties/properties.getcache.php
@@ -60,6 +60,13 @@ $properties = array(
         'options' => '',
         'value' => '',
     )
+    ,array(
+        'name' => 'cacheReset',
+        'desc' => 'If true the current cache of the element is deleted and created new.',
+        'type' => 'combo-boolean',
+        'options' => '',
+        'value' => false,
+    )
 );
 
 return $properties;

--- a/core/components/getcache/docs/changelog.txt
+++ b/core/components/getcache/docs/changelog.txt
@@ -1,5 +1,7 @@
 Changelog for getCache.
 
+- Respect multi-dimensional arrays in request parameters for cacheKey
+
 getPage 1.0.0-pl (March 27, 2011)
 ====================================
 - Change default cacheKey property to use 'resource' (for MODX 2.1+)

--- a/core/components/getcache/docs/readme.txt
+++ b/core/components/getcache/docs/readme.txt
@@ -1,7 +1,7 @@
 --------------------
 Snippet: getCache
 --------------------
-Version: 1.0.0-pl
+Version: 1.0.1-dev
 Since: October 21, 2010
 Author: Jason Coward <jason@modx.com>
 

--- a/core/components/getcache/snippet.getcache.php
+++ b/core/components/getcache/snippet.getcache.php
@@ -3,7 +3,7 @@
  * Cache the output of any MODx Element using a configurable cacheHandler
  *
  * @author Jason Coward <jason@modx.com>
- * @version 1.0.0-pl
+ * @version 1.0.1-dev
  * @since October 24, 2010
  * @package getcache
  */

--- a/core/components/getcache/snippet.getcache.php
+++ b/core/components/getcache/snippet.getcache.php
@@ -24,7 +24,7 @@ unset($properties['filter_modifiers']);
 if (empty($cacheKey)) $cacheKey = $modx->getOption('cache_resource_key', null, 'resource');
 if (empty($cacheHandler)) $cacheHandler = $modx->getOption('cache_resource_handler', null, $modx->getOption(xPDO::OPT_CACHE_HANDLER, null, 'xPDOFileCache'));
 if (!isset($cacheExpires)) $cacheExpires = (integer) $modx->getOption('cache_resource_expires', null, $modx->getOption(xPDO::OPT_CACHE_EXPIRES, null, 0));
-if (empty($cacheElementKey)) $cacheElementKey = $modx->resource->getCacheKey() . '/' . md5($modx->toJSON($properties) . implode('', $modx->request->getParameters()));
+if (empty($cacheElementKey)) $cacheElementKey = $modx->resource->getCacheKey() . '/' . md5($modx->toJSON($properties) . $modx->toJSON($modx->request->getParameters()));
 $cacheOptions = array(
     xPDO::OPT_CACHE_KEY => $cacheKey,
     xPDO::OPT_CACHE_HANDLER => $cacheHandler,

--- a/core/components/getcache/snippet.getcache.php
+++ b/core/components/getcache/snippet.getcache.php
@@ -25,13 +25,14 @@ if (empty($cacheKey)) $cacheKey = $modx->getOption('cache_resource_key', null, '
 if (empty($cacheHandler)) $cacheHandler = $modx->getOption('cache_resource_handler', null, $modx->getOption(xPDO::OPT_CACHE_HANDLER, null, 'xPDOFileCache'));
 if (!isset($cacheExpires)) $cacheExpires = (integer) $modx->getOption('cache_resource_expires', null, $modx->getOption(xPDO::OPT_CACHE_EXPIRES, null, 0));
 if (empty($cacheElementKey)) $cacheElementKey = $modx->resource->getCacheKey() . '/' . md5($modx->toJSON($properties) . $modx->toJSON($modx->request->getParameters()));
+$cacheReset = $modx->getOption('cacheReset', $scriptProperties, false);
 $cacheOptions = array(
     xPDO::OPT_CACHE_KEY => $cacheKey,
     xPDO::OPT_CACHE_HANDLER => $cacheHandler,
     xPDO::OPT_CACHE_EXPIRES => $cacheExpires,
 );
 
-$cached = $modx->cacheManager->get($cacheElementKey, $cacheOptions);
+$cached = (!$cacheReset) ? $modx->cacheManager->get($cacheElementKey, $cacheOptions) : array();
 if (!isset($cached['properties']) || !isset($cached['output'])) {
     $elementObj = $modx->getObject($elementClass, array('name' => $element));
     if ($elementObj) {


### PR DESCRIPTION
With that parameter the cache of the cached element could be reset and filled new. Hope I understood the snippet function right.

I use that on an installation to reset the getCached Wayfinder call periodic once a day on a cronjob page.
